### PR TITLE
Remove msgpack-jruby dependency from gemspec

### DIFF
--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -24,11 +24,10 @@ Gem::Specification.new do |s|
 
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency 'msgpack-jruby'
-  else
-    s.add_runtime_dependency 'msgpack'
   end
-
+  
+  s.add_runtime_dependency 'msgpack'
+  
   s.add_development_dependency 'logstash-devutils', ">= 1.0.0"
 end
 


### PR DESCRIPTION
Recent versions of fluentd don't work with msgpack-jruby.

msgpack-jruby is no longer maintained or updated and is now part of the msgpack gem. (iconara/msgpack-jruby@ebd9205207ef3c97a79b393f3e9b42d16c19588e)
