### PR TITLE
MINOR: Upgrade and fix version of msgpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.1.4
+  - Constrain msgpack dependency to ~> 1.1 due to old versions not containing some format and type definitions
 ## 3.1.3
   - Fix some documentation issues
 

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-fluent'
-  s.version         = '3.1.3'
+  s.version         = '3.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec handles fluentd's msgpack schema."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -22,11 +22,9 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  if RUBY_PLATFORM == 'java'
-    s.platform = RUBY_PLATFORM
-  end
+  s.platform = 'java'
   
-  s.add_runtime_dependency 'msgpack'
+  s.add_runtime_dependency 'msgpack', '~> 1.1'
   
   s.add_development_dependency 'logstash-devutils', ">= 1.0.0"
 end


### PR DESCRIPTION
This was reported to us since the current release seems to run from an older `msgpack` version if the version is not fixed which may be causing trouble.

* Fixed `msgpack` version to latest
* Removed weird JAVA platform conditional that doesn't apply anymore :)