### PR TITLE
Handle EventTime msgpack extension to handle nanosecond precision time and add its parameter

### DIFF
--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -78,6 +78,8 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
   end
 
   class EventTime
+    attr_reader :sec, :nsec
+
     TYPE = 0
 
     def initialize(sec, nsec = 0)
@@ -104,6 +106,15 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
 
   private
 
+  def decode_fluent_time(fluent_time)
+    case fluent_time
+    when Fixnum
+      fluent_time
+    when EventTime
+      Time.at(fluent_time.sec, fluent_time.nsec)
+    end
+  end
+
   def decode_event(data, &block)
     tag = data[0]
     entries = data[1]
@@ -119,7 +130,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
 
       entries_decoder = @decoder
       entries_decoder.feed_each(entries) do |entry|
-        epochtime = entry[0]
+        epochtime = decode_fluent_time(entry[0])
         map = entry[1]
         event = LogStash::Event.new(map.merge(
                                       LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(epochtime),
@@ -130,7 +141,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     when Array
       # Forward
       entries.each do |entry|
-        epochtime = entry[0]
+        epochtime = decode_fluent_time(entry[0])
         map = entry[1]
         event = LogStash::Event.new(map.merge(
                                       LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(epochtime),
@@ -138,9 +149,9 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
                                     ))
         yield event
       end
-    when Fixnum
+    when Fixnum, EventTime
       # Message
-      epochtime = entries
+      epochtime = decode_fluent_time(entries)
       map = data[2]
       event = LogStash::Event.new(map.merge(
                                     LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(epochtime),

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -52,7 +52,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     # Fluentd cannot handle Array class value in forward protocol's tag.
     tag = forwardable_tag(event)
     epochtime = if @nanosecond_precision
-                  EventTime.new(event.timestamp.to_i, event.timestamp.usec)
+                  EventTime.new(event.timestamp.to_i, event.timestamp.usec * 1000)
                 else
                   event.timestamp.to_i
                 end

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -27,6 +27,8 @@ require "logstash/util"
 # * to handle EventTime msgpack extension, you must specify nanosecond_precision parameter as true.
 #
 class LogStash::Codecs::Fluent < LogStash::Codecs::Base
+  require "logstash/codecs/fluent/event_time"
+
   config_name "fluent"
 
   config :nanosecond_precision, :validate => :boolean, :default => false
@@ -75,33 +77,6 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
       tag
     else
       tag.to_s
-    end
-  end
-
-  class EventTime
-    attr_reader :sec, :nsec
-
-    TYPE = 0
-
-    def initialize(sec, nsec = 0)
-      @sec = sec
-      @nsec = nsec
-    end
-
-    def to_msgpack(io = nil)
-      @sec.to_msgpack(io)
-    end
-
-    def to_msgpack_ext
-      [@sec, @nsec].pack('NN')
-    end
-
-    def self.from_msgpack_ext(data)
-      new(*data.unpack('NN'))
-    end
-
-    def to_json(*args)
-      @sec
     end
   end
 

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -10,7 +10,9 @@ require "logstash/util"
 # [source,ruby]
 #     input {
 #       tcp {
-#         codec => fluent
+#         codec => fluent {
+#           nanosecond_precision => true
+#         }
 #         port => 4000
 #       }
 #     }
@@ -22,8 +24,7 @@ require "logstash/util"
 #
 # Notes:
 #
-# * the fluent uses a second-precision time for events, so you will never see
-#   subsecond precision on events processed by this codec.
+# * to handle EventTime msgpack extension, you must specify nanosecond_precision parameter as true.
 #
 class LogStash::Codecs::Fluent < LogStash::Codecs::Base
   config_name "fluent"

--- a/lib/logstash/codecs/fluent/event_time.rb
+++ b/lib/logstash/codecs/fluent/event_time.rb
@@ -1,0 +1,28 @@
+module LogStash; module Codecs; class Fluent;
+  class EventTime
+    attr_reader :sec, :nsec
+
+    TYPE = 0
+
+    def initialize(sec, nsec = 0)
+      @sec = sec
+      @nsec = nsec
+    end
+
+    def to_msgpack(io = nil)
+      @sec.to_msgpack(io)
+    end
+
+    def to_msgpack_ext
+      [@sec, @nsec].pack('NN')
+    end
+
+    def self.from_msgpack_ext(data)
+      new(*data.unpack('NN'))
+    end
+
+    def to_json(*args)
+      @sec
+    end
+  end
+end; end; end

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -70,7 +70,8 @@ describe LogStash::Codecs::Fluent do
   describe "event decoding with EventTime" do
 
     let(:tag)       { "mytag" }
-    let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(event.timestamp.to_i, event.timestamp.usec)  }
+    let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(event.timestamp.to_i,
+                                                              event.timestamp.usec * 1000)  }
     let(:data)      { LogStash::Util.normalize(event.to_hash) }
     let(:message) do
       @packer.pack([tag, epochtime, data.merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)])

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -67,6 +67,24 @@ describe LogStash::Codecs::Fluent do
 
   end
 
+  describe "event decoding with EventTime" do
+
+    let(:tag)       { "mytag" }
+    let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(event.timestamp.to_i, event.timestamp.usec)  }
+    let(:data)      { LogStash::Util.normalize(event.to_hash) }
+    let(:message) do
+      @packer.pack([tag, epochtime, data.merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)])
+    end
+    subject { LogStash::Plugin.lookup("codec", "fluent").new({"nanosecond_precision" => true}) }
+
+    it "should decode without errors" do
+      subject.decode(message) do |event|
+        expect(event.get("name")).to eq("foo")
+      end
+    end
+
+  end
+
   describe "forward protocol tag" do
     let(:event)      { LogStash::Event.new(properties) }
     subject { LogStash::Plugin.lookup("codec", "fluent").new }


### PR DESCRIPTION
Hi, I've tried to handle EventTime msgpack extension in this codec plugin.
How about start to handle EventTime extension?

Regards,
  