### PR TITLE
Handle Time.at second argument correctly

### DIFF
--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -87,7 +87,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     when Fixnum
       fluent_time
     when EventTime
-      Time.at(fluent_time.sec, fluent_time.nsec)
+      Time.at(fluent_time.sec, fluent_time.nsec / 1000.0)
     end
   end
 

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -71,7 +71,7 @@ describe LogStash::Codecs::Fluent do
 
     let(:tag)       { "mytag" }
     let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(event.timestamp.to_i,
-                                                              event.timestamp.usec * 1000)  }
+                                                              event.timestamp.usec)  }
     let(:data)      { LogStash::Util.normalize(event.to_hash) }
     let(:message) do
       @packer.pack([tag, epochtime, data.merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)])


### PR DESCRIPTION
The second argument of Time.at will be handled with usec unit.

Fix for https://github.com/logstash-plugins/logstash-codec-fluent/pull/18#discussion_r486986334.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
