### PR TITLE
Feat: added target configuration + event-factory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.4.0
   - Feat: added target configuration + event-factory support [#27](https://github.com/logstash-plugins/logstash-codec-fluent/pull/27)
+  - Fix: decoding of time's nano-second precision 
 
 ## 3.3.0
   - Handle EventTime msgpack extension to handle nanosecond precision time and add its parameter [#18](https://github.com/logstash-plugins/logstash-codec-fluent/pull/18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+  - Feat: start using an event-factory [#27](https://github.com/logstash-plugins/logstash-codec-fluent/pull/27)
+
 ## 3.3.0
   - Handle EventTime msgpack extension to handle nanosecond precision time and add its parameter [#18](https://github.com/logstash-plugins/logstash-codec-fluent/pull/18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 3.3.1
-  - Feat: start using an event-factory [#27](https://github.com/logstash-plugins/logstash-codec-fluent/pull/27)
+## 3.4.0
+  - Feat: added target configuration + event-factory support [#27](https://github.com/logstash-plugins/logstash-codec-fluent/pull/27)
 
 ## 3.3.0
   - Handle EventTime msgpack extension to handle nanosecond precision time and add its parameter [#18](https://github.com/logstash-plugins/logstash-codec-fluent/pull/18)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,7 +26,9 @@ For example, you can receive logs from `fluent-logger-ruby` with:
 [source,ruby]
     input {
       tcp {
-        codec => fluent
+        codec => fluent {
+          target => '[example]'
+        }
         port => 4000
       }
     }

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,9 +26,7 @@ For example, you can receive logs from `fluent-logger-ruby` with:
 [source,ruby]
     input {
       tcp {
-        codec => fluent {
-          target => '[example]'
-        }
+        codec => fluent
         port => 4000
       }
     }
@@ -42,4 +40,45 @@ Notes:
 
 * the fluent uses a second-precision time for events, so you will never see
   subsecond precision on events processed by this codec.
+
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Fluent Codec configuration options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-nanosecond_precision>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+|=======================================================================
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-nanosecond_precision"]
+===== `nanosecond_precision`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enables sub-second level precision while encoding events.
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Define the target field for placing the decoded values. If this setting is not
+set, data will be stored at the root (top level) of the event.
+
+For example, if you want data to be put under the `logs` field:
+[source,ruby]
+    input {
+      tcp {
+        codec => fluent {
+          target => "[logs]"
+        }
+        port => 4000
+      }
+    }
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,10 +36,9 @@ And from your ruby code in your own application:
     logger = Fluent::Logger::FluentLogger.new(nil, :host => "example.log", :port => 4000)
     logger.post("some_tag", { "your" => "data", "here" => "yay!" })
 
-Notes:
 
-* the fluent uses a second-precision time for events, so you will never see
-  subsecond precision on events processed by this codec.
+NOTE: Fluent uses second-precision for events, so you will not see sub-second precision
+on events processed by this codec.
 
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -100,7 +100,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     when Integer
       fluent_time
     when EventTime
-      Time.at(fluent_time.sec, fluent_time.nsec)
+      Time.at(fluent_time.sec, fluent_time.nsec / 1000.0)
     end
   end
 

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -84,7 +84,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
 
   def decode_fluent_time(fluent_time)
     case fluent_time
-    when Fixnum
+    when Integer
       fluent_time
     when EventTime
       Time.at(fluent_time.sec, fluent_time.nsec)
@@ -125,7 +125,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
                                     ))
         yield event
       end
-    when Fixnum, EventTime
+    when Integer, EventTime
       # Message
       epochtime = decode_fluent_time(entries)
       map = data[2]

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -110,16 +110,16 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
 
       entries_decoder = @decoder
       entries_decoder.feed_each(entries) do |entry|
-        yield new_fluent_event(entry[1], entry[0], tag)
+        yield generate_event(entry[1], entry[0], tag)
       end
     when Array
       # Forward
       entries.each do |entry|
-        yield new_fluent_event(entry[1], entry[0], tag)
+        yield generate_event(entry[1], entry[0], tag)
       end
     when Integer, EventTime
       # Message
-      yield new_fluent_event(data[2], entries, tag)
+      yield generate_event(data[2], entries, tag)
     else
       raise(LogStash::Error, "Unknown event type")
     end
@@ -128,7 +128,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     yield event_factory.new_event("message" => data, "tags" => [ "_fluentparsefailure" ])
   end
 
-  def new_fluent_event(map, fluent_time, tag)
+  def generate_event(map, fluent_time, tag)
     epoch_time = decode_fluent_time(fluent_time)
     event = event_factory.new_event(map)
     event.set(LogStash::Event::TIMESTAMP, LogStash::Timestamp.at(epoch_time))

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require "logstash/codecs/base"
-require "logstash/util/charset"
+require "logstash/event"
 require "logstash/timestamp"
 require "logstash/util"
 

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -128,8 +128,6 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     yield event_factory.new_event("message" => data, "tags" => [ "_fluentparsefailure" ])
   end
 
-  private
-
   def new_fluent_event(map, fluent_time, tag)
     epoch_time = decode_fluent_time(fluent_time)
     event = event_factory.new_event(map)

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-fluent'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the `fluentd` `msgpack` schema"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-fluent'
-  s.version         = '3.3.1'
+  s.version         = '3.4.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the `fluentd` `msgpack` schema"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.platform = 'java'
   

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
 
   s.platform = 'java'
   

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -24,6 +24,10 @@ describe LogStash::Codecs::Fluent do
   let(:tag)  { "mytag" }
   let(:data) { { 'name' => 'foo', 'number' => 42 } }
 
+  let(:message) do
+    @packer.pack([tag, epochtime, data])
+  end
+
   it "should register without errors" do
     plugin = LogStash::Plugin.lookup("codec", "fluent").new
     expect { plugin.register }.to_not raise_error
@@ -86,10 +90,6 @@ describe LogStash::Codecs::Fluent do
 
     let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(timestamp.to_i,
                                                               timestamp.usec * 1000)  }
-    let(:data)      { LogStash::Util.normalize('name' => 'foo', 'number' => 42) }
-    let(:message) do
-      @packer.pack([tag, epochtime, data.merge(LogStash::Event::TIMESTAMP => timestamp.to_iso8601)])
-    end
     subject { LogStash::Plugin.lookup("codec", "fluent").new({"nanosecond_precision" => true}) }
 
     it "should decode without errors" do
@@ -108,9 +108,6 @@ describe LogStash::Codecs::Fluent do
     let(:tag)       { "a_tag" }
     let(:epochtime) { 123 }
     let(:data)      { LogStash::Util.normalize('name' => 'foo') }
-    let(:message) do
-      @packer.pack([tag, epochtime, data])
-    end
 
     let(:config) { super().merge "target" => '[bar]' }
 
@@ -201,9 +198,6 @@ describe LogStash::Codecs::Fluent do
   describe "event decoding (broken package)" do
 
     let(:epochtime) { timestamp.to_s }
-    let(:message) do
-      MessagePack.pack([tag, epochtime, data])
-    end
 
     it "should decode with errors" do
       subject.decode(message) do |event|

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -88,8 +88,8 @@ describe LogStash::Codecs::Fluent do
 
   describe "event decoding with EventTime" do
 
-    let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(timestamp.to_i,
-                                                              timestamp.usec * 1000)  }
+    let(:epochtime) { LogStash::Codecs::Fluent::EventTime.new(timestamp.to_i, (timestamp.usec * 1000) + 123) }
+
     subject { LogStash::Plugin.lookup("codec", "fluent").new({"nanosecond_precision" => true}) }
 
     it "should decode without errors" do
@@ -99,6 +99,13 @@ describe LogStash::Codecs::Fluent do
         decoded = true
       end
       expect(decoded).to be true
+    end
+
+    it "decodes timestamp with nanos" do
+      subject.decode(message) do |event|
+        expect(event.timestamp.to_i).to eql epochtime.sec
+        expect(event.timestamp.usec * 1000 + 123).to eql epochtime.nsec
+      end
     end
 
   end


### PR DESCRIPTION
Sets up usage of LS' `event_factory` support. Also added an optional `config :target`.

Some minor refactorings along the way.
We avoid `Fixnum` Ruby warnings + include a small bug fix for nano-second precision handling.

closes https://github.com/logstash-plugins/logstash-codec-fluent/pull/26