### PR TITLE
decode: handle multiple PackedForward messages in a single payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+  - Fix: handle multiple PackForward-encoded messages in a single payload [#28](https://github.com/logstash-plugins/logstash-codec-fluent/pull/28)
+
 ## 3.4.0
   - Feat: added target configuration + event-factory support [#27](https://github.com/logstash-plugins/logstash-codec-fluent/pull/27)
   - Fix: decoding of time's nano-second precision 

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -117,7 +117,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
         raise(LogStash::Error, "PackedForward with compression is not supported")
       end
 
-      entries_decoder = @decoder
+      entries_decoder = @factory.unpacker
       entries_decoder.feed_each(entries) do |entry|
         yield generate_event(entry[1], entry[0], tag)
       end

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-fluent'
-  s.version         = '3.4.0'
+  s.version         = '3.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the `fluentd` `msgpack` schema"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
MessagePack's `Unpacker` is stateful, and cannot be safely reused while
iterating over results from a previous unpacking.

Internally, `Unpacker#feed_each(input, &block)` buffers the provided input,
and is documented as equivalent to sending `Unpacker#feed(input)` and then
immediately sending `Unpacker#each(&block)`. When we are iterating over the
items, we cannot safely reuse the in-progress unpacker because doing
so feeds the packed payload to the _existing_ buffer.

Instead, we must use our `Factory` to allocate a new `Unpacker`.

There _may_ be optimizations to be had here around reusing an unpacker
for PackedForward-internal unpacking, but these are outside the scope of this
fix.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
