### PR TITLE
Standardize timestamps to mitigate the plugin crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.2
+  - Fix: timestamp values are converted to iso-8601 to resolve the crash [#30](https://github.com/logstash-plugins/logstash-codec-fluent/pull/30)
+
 ## 3.4.1
   - Fix: handle multiple PackForward-encoded messages in a single payload [#28](https://github.com/logstash-plugins/logstash-codec-fluent/pull/28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.2
-  - Fix: timestamp values are converted to iso-8601 to resolve the crash [#30](https://github.com/logstash-plugins/logstash-codec-fluent/pull/30)
+  - Fix: Convert LogStash::Timestamp values to iso-8601 to resolve crash issue with `msgpack` serialization [#30](https://github.com/logstash-plugins/logstash-codec-fluent/pull/30)
 
 ## 3.4.1
   - Fix: handle multiple PackForward-encoded messages in a single payload [#28](https://github.com/logstash-plugins/logstash-codec-fluent/pull/28)

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -75,10 +75,13 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     # use normalize to make sure returned Hash is pure Ruby for
     # MessagePack#pack which relies on pure Ruby object recognition
     data = LogStash::Util.normalize(event.to_hash)
+
     # timestamp is serialized as a iso8601 string
     # merge to avoid modifying data which could have side effects if multiple outputs
+    map_timestamp(data)
+
     @packer.clear
-    @on_event.call(event, @packer.pack([tag, epochtime, data.merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)]))
+    @on_event.call(event, @packer.pack([tag, epochtime, data]))
   end # def encode
 
   def forwardable_tag(event)
@@ -143,6 +146,12 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     event.set(LogStash::Event::TIMESTAMP, LogStash::Timestamp.at(epoch_time))
     event.tag(tag)
     event
+  end
+
+  def map_timestamp(event_hash)
+    event_hash.each do |k, v|
+      event_hash[k] = v.to_iso8601 if v.kind_of?(LogStash::Timestamp)
+    end
   end
 
 end # class LogStash::Codecs::Fluent

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -151,6 +151,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
   def map_timestamp(event_hash)
     event_hash.each do |k, v|
       event_hash[k] = v.to_iso8601 if v.kind_of?(LogStash::Timestamp)
+      event_hash[k] = map_timestamp(v) if v.kind_of?(Hash)
     end
   end
 

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -152,6 +152,9 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     event_hash.each do |k, v|
       event_hash[k] = v.to_iso8601 if v.kind_of?(LogStash::Timestamp)
       event_hash[k] = map_timestamp(v) if v.kind_of?(Hash)
+      if v.kind_of?(Array)
+        event_hash[k] = v.map { |item| item.kind_of?(LogStash::Timestamp) ? item.to_iso8601 : item }
+      end
     end
   end
 

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-fluent'
-  s.version         = '3.4.1'
+  s.version         = '3.4.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the `fluentd` `msgpack` schema"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -48,7 +48,7 @@ describe LogStash::Codecs::Fluent do
   end
 
   describe "when encoding timestamps" do
-    let(:properties) { {:name => "foo", :custom_time => Time.now() } }
+    let(:properties) { {:name => "foo", :custom_time => Time.now(), :time => { :custom_time => Time.now() } } }
 
     it "converts to iso8601 and encodes without issue" do
       subject.on_event do |event, data|
@@ -56,6 +56,8 @@ describe LogStash::Codecs::Fluent do
           expect(fields[0]).to eq("log")
           expect(fields[2]["name"]).to eq("foo")
           expect(fields[2]["custom_time"]).not_to be_nil
+          expect(fields[2]["time"]).not_to be_nil
+          expect(fields[2]["time"]["custom_time"]).not_to be_nil
         end
       end
       subject.encode(event)

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -48,7 +48,7 @@ describe LogStash::Codecs::Fluent do
   end
 
   describe "when encoding timestamps" do
-    let(:properties) { {:name => "foo", :custom_time => Time.now(), :time => { :custom_time => Time.now() } } }
+    let(:properties) { {:name => "foo", :custom_time => Time.now(), :time => { :custom_time => Time.now() }, :custom_times => [Time.now(), Time.now(), "2023-03-28"] } }
 
     it "converts to iso8601 and encodes without issue" do
       subject.on_event do |event, data|
@@ -56,8 +56,13 @@ describe LogStash::Codecs::Fluent do
           expect(fields[0]).to eq("log")
           expect(fields[2]["name"]).to eq("foo")
           expect(fields[2]["custom_time"]).not_to be_nil
+          expect(fields[2]["custom_time"].class).to eql(String) # iso8601 string
           expect(fields[2]["time"]).not_to be_nil
           expect(fields[2]["time"]["custom_time"]).not_to be_nil
+          expect(fields[2]["time"]["custom_time"].class).to eql(String)
+          expect(fields[2]["custom_times"]).not_to be_nil
+          expect(fields[2]["custom_times"][0].class).to eql(String)
+          expect(fields[2]["custom_times"][2]).to eql("2023-03-28")
         end
       end
       subject.encode(event)

--- a/spec/codecs/fluent_spec.rb
+++ b/spec/codecs/fluent_spec.rb
@@ -47,6 +47,21 @@ describe LogStash::Codecs::Fluent do
 
   end
 
+  describe "when encoding timestamps" do
+    let(:properties) { {:name => "foo", :custom_time => Time.now() } }
+
+    it "converts to iso8601 and encodes without issue" do
+      subject.on_event do |event, data|
+        @unpacker.feed_each(data) do |fields|
+          expect(fields[0]).to eq("log")
+          expect(fields[2]["name"]).to eq("foo")
+          expect(fields[2]["custom_time"]).not_to be_nil
+        end
+      end
+      subject.encode(event)
+    end
+  end
+
   describe "event encoding with EventTime" do
 
     let(:config) { super().merge "nanosecond_precision" => true }


### PR DESCRIPTION
## What this PR does?
When sending `LogStash::Timestamp` objects to `fluentd`, it raises `undefined method to_msgpack` exception and plugin crashes. This change introduces to standardize the time objects if event contains and then sends to process the encoding.

- Closes #29 

- Test config
```
input {
  stdin {}
}
filter {
  ruby { code => "event.set('[logstash_timestamp]', Time.now());" }
}
output {
 stdout { codec => fluent }
}
```

- Test logs
```
testing
??log?d{?event??original?testing?host??hostname?Mashhurs-MacBook-Pro.local?@version?1?logstash_timestamp?2023-03-21T09:42:10.001294Z?@timestamp?2023-03-21T09:42:09.890141Z?message?testing
hi
??log?d|!??event??original?hi?host??hostname?Mashhurs-MacBook-Pro.local?@version?1?logstash_timestamp?2023-03-21T09:42:57.873664Z?@timestamp?2023-03-21T09:42:57.764443Z?message?hi

```