### PR TITLE
perf: reuse inner packforward payload unpacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.3
-- Fix: reduce overhead of unpacking packforward-payloads by reusing a single instance
+- Fix: reduce overhead of unpacking packforward-payloads by reusing a single instance [#32](https://github.com/logstash-plugins/logstash-codec-fluent/pull/32)
 
 ## 3.4.2
   - Fix: Convert LogStash::Timestamp values to iso-8601 to resolve crash issue with `msgpack` serialization [#30](https://github.com/logstash-plugins/logstash-codec-fluent/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.3
+- Fix: reduce overhead of unpacking packforward-payloads by reusing a single instance
+
 ## 3.4.2
   - Fix: Convert LogStash::Timestamp values to iso-8601 to resolve crash issue with `msgpack` serialization [#30](https://github.com/logstash-plugins/logstash-codec-fluent/pull/30)
 

--- a/lib/logstash/codecs/fluent.rb
+++ b/lib/logstash/codecs/fluent.rb
@@ -54,6 +54,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
     end
     @packer = @factory.packer
     @decoder = @factory.unpacker
+    @packforward_decoder = nil
   end
 
   def decode(data, &block)
@@ -116,7 +117,7 @@ class LogStash::Codecs::Fluent < LogStash::Codecs::Base
         raise(LogStash::Error, "PackedForward with compression is not supported")
       end
 
-      entries_decoder = @factory.unpacker
+      entries_decoder = (@packforward_decoder ||= @factory.unpacker).tap(&:reset)
       entries_decoder.feed_each(entries) do |entry|
         yield generate_event(entry[1], entry[0], tag)
       end

--- a/logstash-codec-fluent.gemspec
+++ b/logstash-codec-fluent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-fluent'
-  s.version         = '3.4.2'
+  s.version         = '3.4.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the `fluentd` `msgpack` schema"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
A codec instance needs at-most-one packforward payload unpacker, as it is never decoding input concurrently, so long as the unpacker is reset before use.